### PR TITLE
Warn about resources with deletionTimestamp older than N minutes

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,4 +51,6 @@ func init() {
 	rootCmd.PersistentFlags().StringSliceVar(&arguments.ExcludeNamespacePatterns, "exclude-namespace", nil, "Skip the given namespaces. Accepts a comma-separated list. Glob patterns (*, ?, [...]) are supported. Combine with -n to subtract: -n 'foo-*' --exclude-namespace foo-bar checks every foo-* namespace except foo-bar.")
 
 	rootCmd.PersistentFlags().Int16VarP(&arguments.RetryCount, "retry-count", "", 5, "Network errors: How many times to retry the command before giving up. This applies only to the first connection. As soon as a successful connection is made, the command will retry forever. Set to zero to also retry the first connection forever.")
+
+	rootCmd.PersistentFlags().DurationVar(&arguments.WarnDeletionTimestampOlderThan, "warn-deletion-older-than", 10*time.Minute, "Warn about resources whose deletionTimestamp is older than this duration. Set to 0 to disable.")
 }

--- a/pkg/checkconditions/checkconditions.go
+++ b/pkg/checkconditions/checkconditions.go
@@ -43,7 +43,10 @@ type Arguments struct {
 	RetryCount               int16
 	RetryForEver             bool
 	Timeout                  time.Duration
-	forbiddenResourcesPrinted bool
+	// WarnDeletionTimestampOlderThan warns about resources whose deletionTimestamp
+	// is older than this duration. Set to 0 to disable.
+	WarnDeletionTimestampOlderThan time.Duration
+	forbiddenResourcesPrinted      bool
 }
 
 // matchAnyPattern reports whether name matches any of the given glob patterns.
@@ -485,6 +488,16 @@ func printResources(args *Arguments, list *unstructured.UnstructuredList, gvr sc
 			continue
 		}
 		counter.checkedResources++
+		if args.WarnDeletionTimestampOlderThan > 0 {
+			if dt := obj.GetDeletionTimestamp(); dt != nil && !dt.IsZero() {
+				age := time.Since(dt.Time)
+				if age > args.WarnDeletionTimestampOlderThan {
+					line := fmt.Sprintf("  %s %s %s DeletionTimestamp set for %s",
+						obj.GetNamespace(), gvr.Resource, obj.GetName(), age.Round(time.Second))
+					lines = append(lines, line)
+				}
+			}
+		}
 		var conditions []interface{}
 		var err error
 		if gvr.Resource == "hetznerbaremetalhosts" {

--- a/pkg/checkconditions/checkconditions_test.go
+++ b/pkg/checkconditions/checkconditions_test.go
@@ -1,8 +1,12 @@
 package checkconditions
 
 import (
+	"strings"
 	"testing"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -35,5 +39,75 @@ func TestHandleConditionSkipsHealthyMachineConditions(t *testing.T) {
 	}
 	if counter.checkedConditions != int32(len(tests)) {
 		t.Fatalf("expected %d checked conditions, got %d", len(tests), counter.checkedConditions)
+	}
+}
+
+func TestPrintResourcesWarnsDeletionTimestamp(t *testing.T) {
+	gvr := schema.GroupVersionResource{Resource: "pods"}
+	args := &Arguments{
+		WarnDeletionTimestampOlderThan: 10 * time.Minute,
+	}
+
+	oldTime := metav1.NewTime(time.Now().Add(-15 * time.Minute))
+	obj := unstructured.Unstructured{}
+	obj.SetName("stuck-pod")
+	obj.SetNamespace("default")
+	obj.SetDeletionTimestamp(&oldTime)
+
+	list := &unstructured.UnstructuredList{Items: []unstructured.Unstructured{obj}}
+	counter := &handleResourceTypeOutput{}
+	lines, _ := printResources(args, list, gvr, counter, 0)
+
+	if len(lines) == 0 {
+		t.Fatal("expected a warning line for old deletionTimestamp, got none")
+	}
+	if !strings.Contains(lines[0], "DeletionTimestamp") {
+		t.Errorf("expected line to mention DeletionTimestamp, got: %s", lines[0])
+	}
+}
+
+func TestPrintResourcesNoWarnRecentDeletionTimestamp(t *testing.T) {
+	gvr := schema.GroupVersionResource{Resource: "pods"}
+	args := &Arguments{
+		WarnDeletionTimestampOlderThan: 10 * time.Minute,
+	}
+
+	recentTime := metav1.NewTime(time.Now().Add(-1 * time.Minute))
+	obj := unstructured.Unstructured{}
+	obj.SetName("deleting-pod")
+	obj.SetNamespace("default")
+	obj.SetDeletionTimestamp(&recentTime)
+
+	list := &unstructured.UnstructuredList{Items: []unstructured.Unstructured{obj}}
+	counter := &handleResourceTypeOutput{}
+	lines, _ := printResources(args, list, gvr, counter, 0)
+
+	for _, l := range lines {
+		if strings.Contains(l, "DeletionTimestamp") {
+			t.Errorf("expected no warning for recent deletionTimestamp, got: %s", l)
+		}
+	}
+}
+
+func TestPrintResourcesDisabledDeletionTimestampCheck(t *testing.T) {
+	gvr := schema.GroupVersionResource{Resource: "pods"}
+	args := &Arguments{
+		WarnDeletionTimestampOlderThan: 0, // disabled
+	}
+
+	oldTime := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+	obj := unstructured.Unstructured{}
+	obj.SetName("old-pod")
+	obj.SetNamespace("default")
+	obj.SetDeletionTimestamp(&oldTime)
+
+	list := &unstructured.UnstructuredList{Items: []unstructured.Unstructured{obj}}
+	counter := &handleResourceTypeOutput{}
+	lines, _ := printResources(args, list, gvr, counter, 0)
+
+	for _, l := range lines {
+		if strings.Contains(l, "DeletionTimestamp") {
+			t.Errorf("expected no warning when check is disabled, got: %s", l)
+		}
 	}
 }


### PR DESCRIPTION
Closes #28

## Summary

- Adds `--warn-deletion-older-than` flag (default: `10m`) to all subcommands
- When a resource's `metadata.deletionTimestamp` has been set for longer than the configured duration, a warning line is emitted in the form:
  ```
    <namespace> <resource> <name> DeletionTimestamp set for <age>
  ```
- Set `--warn-deletion-older-than=0` to disable the check entirely

## Test plan

- [x] `TestPrintResourcesWarnsDeletionTimestamp` — old deletionTimestamp (15m) triggers warning with default 10m threshold
- [x] `TestPrintResourcesNoWarnRecentDeletionTimestamp` — recent deletionTimestamp (1m) does not trigger warning
- [x] `TestPrintResourcesDisabledDeletionTimestampCheck` — threshold=0 disables check even for very old timestamps
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)