### PR TITLE
Print connected cluster, time and kubeconfig source

### DIFF
--- a/pkg/checkconditions/checkconditions.go
+++ b/pkg/checkconditions/checkconditions.go
@@ -47,6 +47,7 @@ type Arguments struct {
 	// is older than this duration. Set to 0 to disable.
 	WarnDeletionTimestampOlderThan time.Duration
 	forbiddenResourcesPrinted      bool
+	connectionInfoPrinted          bool
 }
 
 // matchAnyPattern reports whether name matches any of the given glob patterns.
@@ -227,7 +228,53 @@ func RunAllOnce(ctx context.Context, args *Arguments) (bool, error) {
 	// to wait for getting results from an api-server running at localhost
 	config.QPS = 1000
 	config.Burst = 1000
+
+	// Print the connected cluster and where the kubeconfig comes from once per
+	// invocation. The while/forever loops call RunAllOnce repeatedly, so guard
+	// against printing this block on every iteration.
+	if !args.connectionInfoPrinted {
+		printConnectionInfo(kubeconfig, loadingRules, config)
+		args.connectionInfoPrinted = true
+	}
+
 	return RunCheckAllConditions(ctx, config, args)
+}
+
+// printConnectionInfo prints the connected cluster (server URL and kube-context),
+// the current time and where the kubeconfig was loaded from.
+func printConnectionInfo(kubeconfig clientcmd.ClientConfig, loadingRules *clientcmd.ClientConfigLoadingRules, config *restclient.Config) {
+	server := config.Host
+	contextName := ""
+	if rawConfig, err := kubeconfig.RawConfig(); err == nil {
+		contextName = rawConfig.CurrentContext
+		if cluster, ok := rawConfig.Clusters[rawConfig.Contexts[contextName].Cluster]; ok && cluster.Server != "" {
+			server = cluster.Server
+		}
+	}
+	if contextName != "" {
+		fmt.Printf("Cluster:    %s (context %q)\n", server, contextName)
+	} else {
+		fmt.Printf("Cluster:    %s\n", server)
+	}
+	fmt.Printf("Kubeconfig: %s\n", kubeconfigSource(loadingRules))
+	fmt.Printf("Time:       %s\n\n", time.Now().Format("2006-01-02 15:04:05 -0700 MST"))
+}
+
+// kubeconfigSource returns a human readable description of where the kubeconfig
+// was loaded from.
+func kubeconfigSource(loadingRules *clientcmd.ClientConfigLoadingRules) string {
+	if loadingRules.ExplicitPath != "" {
+		return loadingRules.ExplicitPath
+	}
+	files := loadingRules.GetLoadingPrecedence()
+	if len(files) == 0 {
+		return "unknown"
+	}
+	source := strings.Join(files, string(os.PathListSeparator))
+	if os.Getenv(clientcmd.RecommendedConfigPathEnvVar) != "" {
+		source += " (from $" + clientcmd.RecommendedConfigPathEnvVar + ")"
+	}
+	return source
 }
 
 func RunForever(ctx context.Context, args *Arguments) error {

--- a/pkg/checkconditions/checkconditions_test.go
+++ b/pkg/checkconditions/checkconditions_test.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 func TestHandleConditionSkipsHealthyMachineConditions(t *testing.T) {
@@ -168,4 +169,30 @@ func TestPrintResourcesDisabledDeletionTimestampCheck(t *testing.T) {
 			t.Errorf("expected no warning when check is disabled, got: %s", l)
 		}
 	}
+}
+
+func TestKubeconfigSource(t *testing.T) {
+	t.Run("explicit path wins", func(t *testing.T) {
+		rules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: "/tmp/explicit"}
+		if got := kubeconfigSource(rules); got != "/tmp/explicit" {
+			t.Errorf("expected explicit path, got %q", got)
+		}
+	})
+
+	t.Run("precedence list without KUBECONFIG env", func(t *testing.T) {
+		t.Setenv(clientcmd.RecommendedConfigPathEnvVar, "")
+		rules := &clientcmd.ClientConfigLoadingRules{Precedence: []string{"/home/user/.kube/config"}}
+		if got := kubeconfigSource(rules); got != "/home/user/.kube/config" {
+			t.Errorf("unexpected source %q", got)
+		}
+	})
+
+	t.Run("notes KUBECONFIG env when set", func(t *testing.T) {
+		t.Setenv(clientcmd.RecommendedConfigPathEnvVar, "/env/config")
+		rules := &clientcmd.ClientConfigLoadingRules{Precedence: []string{"/env/config"}}
+		got := kubeconfigSource(rules)
+		if !strings.Contains(got, "/env/config") || !strings.Contains(got, "$"+clientcmd.RecommendedConfigPathEnvVar) {
+			t.Errorf("expected source to note KUBECONFIG env, got %q", got)
+		}
+	})
 }


### PR DESCRIPTION
<!-- agentloop:ui-link -->
[Open in AgentLoop UI](https://agentloop.thomas-guettler.de/issues/check-conditions/12)
<!-- /agentloop:ui-link -->

<!-- agentloop:issue-link -->
Closes #12 — Print connected cluster.
<!-- /agentloop:issue-link -->

Closes #12

## What changed

At startup the tool now prints a one-time connection block:

```
Cluster:    https://127.0.0.1:6443 (context "kind-kind")
Kubeconfig: /home/user/.kube/config
Time:       2026-08-28 15:04:05 +0000 UTC
```

- **Cluster**: server URL (from the current context's cluster, falling back to `config.Host`) plus the kube-context name.
- **Kubeconfig**: where the config was loaded from — the explicit path if set, otherwise the loading-precedence file list, with a `(from $KUBECONFIG)` note when that env var is set.
- **Time**: the current time, matching the format already used in the while/forever loops.

The block is printed once per invocation, guarded by a `connectionInfoPrinted` flag on `Arguments`, so the `while`/`forever` loops (which call `RunAllOnce` repeatedly) don't spam it every iteration. The existing per-iteration timestamps are unchanged.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./...` — all pass, including a new `TestKubeconfigSource` covering explicit path, precedence list, and the `$KUBECONFIG` note.
- `golangci-lint run` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)