### PR TITLE
Show desired vs. available replicas for MinimumReplicasUnavailable

### DIFF
--- a/pkg/checkconditions/checkconditions.go
+++ b/pkg/checkconditions/checkconditions.go
@@ -671,8 +671,15 @@ func printConditions(args *Arguments, conditions []interface{}, counter *handleR
 			duration = fmt.Sprint(d.Round(time.Second))
 		}
 
-		outLine := fmt.Sprintf("  %s %s %s Condition %s=%s %s %q (%s)", obj.GetNamespace(), gvr.Resource, obj.GetName(), r.conditionType, r.conditionStatus,
-			r.conditionReason, r.conditionMessage, duration)
+		detail := ""
+		if gvr.Resource == "deployments" && r.conditionReason == "MinimumReplicasUnavailable" {
+			if d := deploymentReplicaDetail(obj); d != "" {
+				detail = " " + d
+			}
+		}
+
+		outLine := fmt.Sprintf("  %s %s %s Condition %s=%s %s %q (%s)%s", obj.GetNamespace(), gvr.Resource, obj.GetName(), r.conditionType, r.conditionStatus,
+			r.conditionReason, r.conditionMessage, duration, detail)
 
 		addLine := true
 		if args.WhileRegex != nil {
@@ -680,9 +687,9 @@ func printConditions(args *Arguments, conditions []interface{}, counter *handleR
 			// Check each individual type for backward compatibility with --while regexes
 			// that match on a specific condition type name (e.g. "Failed=True").
 			for _, t := range e.types {
-				singleLine := fmt.Sprintf("  %s %s %s Condition %s=%s %s %q (%s)",
+				singleLine := fmt.Sprintf("  %s %s %s Condition %s=%s %s %q (%s)%s",
 					obj.GetNamespace(), gvr.Resource, obj.GetName(),
-					t, r.conditionStatus, r.conditionReason, r.conditionMessage, duration)
+					t, r.conditionStatus, r.conditionReason, r.conditionMessage, duration, detail)
 				if args.WhileRegex.MatchString(singleLine) {
 					again = true
 					addLine = true
@@ -701,6 +708,24 @@ func printConditions(args *Arguments, conditions []interface{}, counter *handleR
 		}
 	}
 	return lines, again
+}
+
+// deploymentReplicaDetail returns a fragment like "available 1/3" describing how many
+// replicas are available versus desired. Desired defaults to 1 when spec.replicas is absent
+// (matching Kubernetes' default), available defaults to 0. Returns "" if the numbers can't be read.
+func deploymentReplicaDetail(obj unstructured.Unstructured) string {
+	desired, found, err := unstructured.NestedInt64(obj.Object, "spec", "replicas")
+	if err != nil {
+		return ""
+	}
+	if !found {
+		desired = 1
+	}
+	available, _, err := unstructured.NestedInt64(obj.Object, "status", "availableReplicas")
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("available %d/%d", available, desired)
 }
 
 func handleCondition(condition interface{}, counter *handleResourceTypeOutput, gvr schema.GroupVersionResource, rows []conditionRow) []conditionRow {

--- a/pkg/checkconditions/checkconditions_test.go
+++ b/pkg/checkconditions/checkconditions_test.go
@@ -101,6 +101,89 @@ func TestPrintConditionsMergesDuplicateReasonMessage(t *testing.T) {
 	}
 }
 
+func newDeploymentWithMinimumReplicasUnavailable(desired, available *int64) unstructured.Unstructured {
+	obj := unstructured.Unstructured{}
+	obj.SetName("topolvm-controller")
+	obj.SetNamespace("topolvm-system")
+	if desired != nil {
+		_ = unstructured.SetNestedField(obj.Object, *desired, "spec", "replicas")
+	}
+	if available != nil {
+		_ = unstructured.SetNestedField(obj.Object, *available, "status", "availableReplicas")
+	}
+	return obj
+}
+
+func minimumReplicasUnavailableConditions() []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"type":    "Available",
+			"status":  "False",
+			"reason":  "MinimumReplicasUnavailable",
+			"message": "Deployment does not have minimum availability.",
+		},
+	}
+}
+
+func TestPrintConditionsAppendsDeploymentReplicaDetail(t *testing.T) {
+	gvr := schema.GroupVersionResource{Resource: "deployments"}
+	args := &Arguments{}
+	desired, available := int64(3), int64(1)
+	obj := newDeploymentWithMinimumReplicasUnavailable(&desired, &available)
+
+	counter := &handleResourceTypeOutput{}
+	lines, _ := printConditions(args, minimumReplicasUnavailableConditions(), counter, gvr, obj)
+
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "available 1/3") {
+		t.Errorf("expected replica detail in output, got: %s", lines[0])
+	}
+}
+
+func TestPrintConditionsReplicaDetailMissingAvailableReplicas(t *testing.T) {
+	gvr := schema.GroupVersionResource{Resource: "deployments"}
+	args := &Arguments{}
+	desired := int64(3)
+	obj := newDeploymentWithMinimumReplicasUnavailable(&desired, nil)
+
+	counter := &handleResourceTypeOutput{}
+	lines, _ := printConditions(args, minimumReplicasUnavailableConditions(), counter, gvr, obj)
+
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "available 0/3") {
+		t.Errorf("expected available 0/3 when availableReplicas absent, got: %s", lines[0])
+	}
+}
+
+func TestPrintConditionsNoReplicaDetailForOtherReason(t *testing.T) {
+	gvr := schema.GroupVersionResource{Resource: "deployments"}
+	args := &Arguments{}
+	desired, available := int64(3), int64(1)
+	obj := newDeploymentWithMinimumReplicasUnavailable(&desired, &available)
+
+	conditions := []interface{}{
+		map[string]interface{}{
+			"type":    "Progressing",
+			"status":  "False",
+			"reason":  "ProgressDeadlineExceeded",
+			"message": "ReplicaSet has timed out progressing.",
+		},
+	}
+	counter := &handleResourceTypeOutput{}
+	lines, _ := printConditions(args, conditions, counter, gvr, obj)
+
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d: %v", len(lines), lines)
+	}
+	if strings.Contains(lines[0], "available") {
+		t.Errorf("did not expect replica detail for non-MinimumReplicasUnavailable reason, got: %s", lines[0])
+	}
+}
+
 func TestPrintResourcesWarnsDeletionTimestamp(t *testing.T) {
 	gvr := schema.GroupVersionResource{Resource: "pods"}
 	args := &Arguments{


### PR DESCRIPTION
<!-- agentloop:ui-link -->
[Open in AgentLoop UI](https://agentloop.thomas-guettler.de/issues/check-conditions/11)
<!-- /agentloop:ui-link -->

<!-- agentloop:issue-link -->
Closes #11 — Show more details if MinimumReplicasUnavailable
<!-- /agentloop:issue-link -->

Closes #11

## What changed

When a Deployment reports `Available=False` / `MinimumReplicasUnavailable`, the output line now appends the actual replica counts:

```
  topolvm-system deployments topolvm-controller Condition Available=False MinimumReplicasUnavailable "Deployment does not have minimum availability." (3m1s) available 1/3
```

- New helper `deploymentReplicaDetail` reads `status.availableReplicas` (default 0) and `spec.replicas` (default 1, matching Kubernetes' default) from the object already in hand — no extra API calls.
- The `available <n>/<desired>` fragment is appended only for `deployments` with reason `MinimumReplicasUnavailable`. It degrades gracefully (empty) if the numbers can't be read.
- Appended to both the printed line and the per-type `--while` regex line so matching stays consistent.

## How verified

- `go test ./...` passes, including three new tests:
  - detail appended (`available 1/3`)
  - missing `availableReplicas` → `available 0/3`, no panic
  - no suffix for other reasons
- `go vet ./...` clean.