### PR TITLE
Treat a starting pod's not-ready conditions as healthy

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ go run github.com/guettli/check-conditions@latest all -n 'foo-*' --exclude-names
 go run github.com/guettli/check-conditions@latest all --exclude-namespace 'kube-*,longhorn-system'
 ```
 
+A Pod that just started reports `ContainersReady=False` / `Initialized=False` for a few seconds. This is expected, not a problem. By default such conditions are treated as healthy while the pod is starting for the first time (no container restarts yet) and the condition is younger than 30 seconds. Use `--pod-start-grace` to change the duration, or set it to `0` to always report these conditions:
+
+```console
+go run github.com/guettli/check-conditions@latest all --pod-start-grace 1m
+```
+
 ## Terminology
 
 Since I found not good umbrella term for CRDs and core resource types, I use the term CRD.
@@ -140,6 +146,7 @@ HTML GUI via localhost.
 Negative conditions are ok for a defined time period.
 Example: It is ok if a Pod needs 20 seconds to start.
 But it is not ok if it takes 5 minutes.
+(Implemented for pod startup via `--pod-start-grace`; still open for other conditions.)
 
 To make warnings appear sooner after starting the programm
 (it takes 20 secs even for small clusters), we could

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,4 +65,6 @@ func init() {
 	rootCmd.PersistentFlags().Int16VarP(&arguments.RetryCount, "retry-count", "", 5, "Network errors: How many times to retry the command before giving up. This applies only to the first connection. As soon as a successful connection is made, the command will retry forever. Set to zero to also retry the first connection forever.")
 
 	rootCmd.PersistentFlags().DurationVar(&arguments.WarnDeletionTimestampOlderThan, "warn-deletion-older-than", 10*time.Minute, "Warn about resources whose deletionTimestamp is older than this duration. Set to 0 to disable.")
+
+	rootCmd.PersistentFlags().DurationVar(&arguments.PodStartGracePeriod, "pod-start-grace", 30*time.Second, "Treat a Pod whose ContainersReady/Initialized condition is False as healthy while it is still starting for the first time (no restarts) and younger than this duration. Set to 0 to disable.")
 }

--- a/pkg/checkconditions/checkconditions.go
+++ b/pkg/checkconditions/checkconditions.go
@@ -46,8 +46,13 @@ type Arguments struct {
 	// WarnDeletionTimestampOlderThan warns about resources whose deletionTimestamp
 	// is older than this duration. Set to 0 to disable.
 	WarnDeletionTimestampOlderThan time.Duration
-	forbiddenResourcesPrinted      bool
-	connectionInfoPrinted          bool
+	// PodStartGracePeriod suppresses "pod is still starting" noise: a Pod whose
+	// ContainersReady/Initialized condition is False but younger than this
+	// duration, and which has not restarted yet, is treated as healthy. Set to 0
+	// to disable.
+	PodStartGracePeriod       time.Duration
+	forbiddenResourcesPrinted bool
+	connectionInfoPrinted     bool
 }
 
 // matchAnyPattern reports whether name matches any of the given glob patterns.
@@ -608,6 +613,19 @@ func printConditions(args *Arguments, conditions []interface{}, counter *handleR
 	for _, condition := range conditions {
 		rows = handleCondition(condition, counter, gvr, rows)
 	}
+	// Suppress "pod is still starting" noise: while a pod is starting for the
+	// first time (no restarts), a recent ContainersReady=False / Initialized=False
+	// is expected and not worth reporting.
+	if gvr.Resource == "pods" && args.PodStartGracePeriod > 0 && podHasNoRestarts(obj) {
+		filtered := rows[:0]
+		for _, r := range rows {
+			if podStartingCondition(r, args.PodStartGracePeriod) {
+				continue
+			}
+			filtered = append(filtered, r)
+		}
+		rows = filtered
+	}
 	// remove general ready condition, if it is already contained in a particular condition
 	// https://pkg.go.dev/sigs.k8s.io/cluster-api/util/conditions#SetSummary
 	var ready *conditionRow
@@ -708,6 +726,47 @@ func printConditions(args *Arguments, conditions []interface{}, counter *handleR
 		}
 	}
 	return lines, again
+}
+
+// podStartingCondition reports whether a condition row is a pod that is still
+// starting for the first time: a ContainersReady/Initialized condition that is
+// False and younger than the grace period. A missing lastTransitionTime is left
+// untouched (reported) so nothing is hidden without evidence it is recent.
+func podStartingCondition(r conditionRow, grace time.Duration) bool {
+	if r.conditionStatus != "False" {
+		return false
+	}
+	if r.conditionType != "ContainersReady" && r.conditionType != "Initialized" {
+		return false
+	}
+	if r.conditionLastTransitionTime.IsZero() {
+		return false
+	}
+	return time.Since(r.conditionLastTransitionTime) < grace
+}
+
+// podHasNoRestarts reports whether none of the pod's containers have restarted
+// yet. A restart means the pod already ran once, so a not-ready condition is no
+// longer a first-start situation and should be reported. Missing restartCount
+// fields count as zero restarts.
+func podHasNoRestarts(obj unstructured.Unstructured) bool {
+	for _, key := range []string{"containerStatuses", "initContainerStatuses"} {
+		statuses, _, err := unstructured.NestedSlice(obj.Object, "status", key)
+		if err != nil {
+			continue
+		}
+		for _, s := range statuses {
+			m, ok := s.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			restarts, found, err := unstructured.NestedInt64(m, "restartCount")
+			if err == nil && found && restarts > 0 {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // deploymentReplicaDetail returns a fragment like "available 1/3" describing how many

--- a/pkg/checkconditions/checkconditions_test.go
+++ b/pkg/checkconditions/checkconditions_test.go
@@ -254,6 +254,93 @@ func TestPrintResourcesDisabledDeletionTimestampCheck(t *testing.T) {
 	}
 }
 
+func newStartingPod(restartCount int64) unstructured.Unstructured {
+	obj := unstructured.Unstructured{}
+	obj.SetName("agentloop-sharedinbox-issue-300-run")
+	obj.SetNamespace("agentloop")
+	if restartCount > 0 {
+		_ = unstructured.SetNestedSlice(obj.Object, []interface{}{
+			map[string]interface{}{
+				"name":         "worker",
+				"restartCount": restartCount,
+			},
+		}, "status", "containerStatuses")
+	}
+	return obj
+}
+
+func startingPodConditions(transition time.Time) []interface{} {
+	ts := transition.Format(time.RFC3339)
+	return []interface{}{
+		map[string]interface{}{
+			"type":               "ContainersReady",
+			"status":             "False",
+			"reason":             "ContainersNotReady",
+			"message":            "containers with unready status: [worker]",
+			"lastTransitionTime": ts,
+		},
+		map[string]interface{}{
+			"type":               "Initialized",
+			"status":             "False",
+			"reason":             "ContainersNotInitialized",
+			"message":            "containers with incomplete status: [inject-agentloop]",
+			"lastTransitionTime": ts,
+		},
+	}
+}
+
+func TestPrintConditionsSuppressesStartingPod(t *testing.T) {
+	gvr := schema.GroupVersionResource{Resource: "pods"}
+	args := &Arguments{PodStartGracePeriod: 30 * time.Second}
+	obj := newStartingPod(0)
+
+	counter := &handleResourceTypeOutput{}
+	lines, _ := printConditions(args, startingPodConditions(time.Now().Add(-3*time.Second)), counter, gvr, obj)
+
+	if len(lines) != 0 {
+		t.Fatalf("expected starting pod conditions to be suppressed, got %d lines: %v", len(lines), lines)
+	}
+}
+
+func TestPrintConditionsReportsStalledPod(t *testing.T) {
+	gvr := schema.GroupVersionResource{Resource: "pods"}
+	args := &Arguments{PodStartGracePeriod: 30 * time.Second}
+	obj := newStartingPod(0)
+
+	counter := &handleResourceTypeOutput{}
+	lines, _ := printConditions(args, startingPodConditions(time.Now().Add(-5*time.Minute)), counter, gvr, obj)
+
+	if len(lines) == 0 {
+		t.Fatal("expected a warning line for a pod stuck past the grace period, got none")
+	}
+}
+
+func TestPrintConditionsReportsRestartedPod(t *testing.T) {
+	gvr := schema.GroupVersionResource{Resource: "pods"}
+	args := &Arguments{PodStartGracePeriod: 30 * time.Second}
+	obj := newStartingPod(1)
+
+	counter := &handleResourceTypeOutput{}
+	lines, _ := printConditions(args, startingPodConditions(time.Now().Add(-3*time.Second)), counter, gvr, obj)
+
+	if len(lines) == 0 {
+		t.Fatal("expected a warning line for a restarted pod even within the grace period, got none")
+	}
+}
+
+func TestPrintConditionsGraceDisabled(t *testing.T) {
+	gvr := schema.GroupVersionResource{Resource: "pods"}
+	args := &Arguments{PodStartGracePeriod: 0}
+	obj := newStartingPod(0)
+
+	counter := &handleResourceTypeOutput{}
+	lines, _ := printConditions(args, startingPodConditions(time.Now().Add(-3*time.Second)), counter, gvr, obj)
+
+	if len(lines) == 0 {
+		t.Fatal("expected a warning line when the grace period is disabled, got none")
+	}
+}
+
 func TestKubeconfigSource(t *testing.T) {
 	t.Run("explicit path wins", func(t *testing.T) {
 		rules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: "/tmp/explicit"}


### PR DESCRIPTION
<!-- agentloop:ui-link -->
[Open in AgentLoop UI](https://agentloop.thomas-guettler.de/issues/check-conditions/30)
<!-- /agentloop:ui-link -->

<!-- agentloop:issue-link -->
Closes #30 — Starting container is ok
<!-- /agentloop:issue-link -->

Closes #30

## What

A Pod that just started reports `ContainersReady=False` / `Initialized=False` for a few seconds. This is expected, not a problem, but `check-conditions` printed it as a warning and exited non-zero:

```
agentloop pods ...-75099548425 Condition ContainersReady=False ContainersNotReady "containers with unready status: [worker]" (3s)
agentloop pods ...-75099548425 Condition Initialized=False ContainersNotInitialized "containers with incomplete status: [inject-agentloop]" (3s)
```

This PR treats such conditions as healthy while the pod is starting **for the first time** (no container restarts yet) and the condition is **younger than a grace period**.

## How

- New `--pod-start-grace` flag on `Arguments.PodStartGracePeriod` (default `30s`, `0` disables), mirroring the existing `--warn-deletion-older-than` pattern.
- In `printConditions`, before the merge/skip-Ready logic, drop a pod's `ContainersReady=False` / `Initialized=False` row when the pod has no restarts (`podHasNoRestarts`, reading `status.containerStatuses` / `status.initContainerStatuses`) and the condition's `lastTransitionTime` is within the grace period (`podStartingCondition`).
- A missing `lastTransitionTime` leaves the row untouched (reported), so nothing is hidden without evidence it is recent. Crash-looping pods keep an old transition time and fall outside the window, so they stay reported.
- README documents the flag and marks the wishlist item as implemented for pod startup.

## Verification

- Added tests: `TestPrintConditionsSuppressesStartingPod`, `TestPrintConditionsReportsStalledPod`, `TestPrintConditionsReportsRestartedPod`, `TestPrintConditionsGraceDisabled`.
- `go test ./...` passes; `golangci-lint run` reports `0 issues`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)