### PR TITLE
Ignore healthy tigera/installations conditions (Degraded/Progressing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Examples:
 * *Ready=True will be ignored
 * *Healthy=True will be ignored
 * *Pressure=False will be ignored.
+* *Degraded=False will be ignored.
 
 ## Command "while"
 

--- a/pkg/checkconditions/checkconditions.go
+++ b/pkg/checkconditions/checkconditions.go
@@ -914,6 +914,10 @@ var conditionLinesToIgnoreRegexs = []*regexp.Regexp{
 
 	// liqo
 	regexp.MustCompile(`foreignclusters APIServerStatus=Established`),
+
+	// Tigera / Calico operator
+	regexp.MustCompile(`tigerastatuses Progressing=False AllObjectsAvailable`),
+	regexp.MustCompile(`installations Progressing=False AllObjectsAvailable`),
 }
 
 func conditionTypeHasPositiveMeaning(resource string, ct string) bool {
@@ -996,7 +1000,7 @@ func conditionTypeHasNegativeMeaning(resource string, ct string) bool {
 	}
 
 	for _, suffix := range []string{
-		"Unavailable", "Pressure", "Dangling", "Unhealthy", "Paused", "Deleting", "Failed",
+		"Unavailable", "Pressure", "Dangling", "Unhealthy", "Paused", "Deleting", "Failed", "Degraded",
 	} {
 		if strings.HasSuffix(ct, suffix) {
 			return true

--- a/pkg/checkconditions/checkconditions_test.go
+++ b/pkg/checkconditions/checkconditions_test.go
@@ -69,6 +69,97 @@ func TestHandleConditionSkipsHealthyForeignClusterConditions(t *testing.T) {
 	}
 }
 
+func TestHandleConditionSkipsHealthyTigeraConditions(t *testing.T) {
+	tests := []struct {
+		name      string
+		resource  string
+		condition map[string]interface{}
+		wantRows  int
+	}{
+		{
+			name:     "tigerastatuses Degraded=False is healthy",
+			resource: "tigerastatuses",
+			condition: map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"reason":  "AllObjectsAvailable",
+				"message": "All Objects Available",
+			},
+			wantRows: 0,
+		},
+		{
+			name:     "tigerastatuses Progressing=False is healthy",
+			resource: "tigerastatuses",
+			condition: map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "False",
+				"reason":  "AllObjectsAvailable",
+				"message": "All Objects Available",
+			},
+			wantRows: 0,
+		},
+		{
+			name:     "installations Degraded=False is healthy",
+			resource: "installations",
+			condition: map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"reason":  "AllObjectsAvailable",
+				"message": "All Objects Available",
+			},
+			wantRows: 0,
+		},
+		{
+			name:     "installations Progressing=False is healthy",
+			resource: "installations",
+			condition: map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "False",
+				"reason":  "AllObjectsAvailable",
+				"message": "All Objects Available",
+			},
+			wantRows: 0,
+		},
+		{
+			name:     "generic Degraded=False is healthy",
+			resource: "somethingelse",
+			condition: map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"reason":  "AsExpected",
+				"message": "",
+			},
+			wantRows: 0,
+		},
+		{
+			name:     "deployments Progressing=False ProgressDeadlineExceeded is still reported",
+			resource: "deployments",
+			condition: map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "False",
+				"reason":  "ProgressDeadlineExceeded",
+				"message": `ReplicaSet "istio-ingressgateway-76dc58b7f" has timed out progressing.`,
+			},
+			wantRows: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gvr := schema.GroupVersionResource{Resource: tc.resource}
+			counter := &handleResourceTypeOutput{}
+			var rows []conditionRow
+			rows = handleCondition(tc.condition, counter, gvr, rows)
+			if len(rows) != tc.wantRows {
+				t.Fatalf("expected %d rows, got %d: %v", tc.wantRows, len(rows), rows)
+			}
+			if counter.checkedConditions != 1 {
+				t.Fatalf("expected 1 checked condition, got %d", counter.checkedConditions)
+			}
+		})
+	}
+}
+
 func TestPrintConditionsMergesDuplicateReasonMessage(t *testing.T) {
 	gvr := schema.GroupVersionResource{Resource: "jobs"}
 	args := &Arguments{}


### PR DESCRIPTION
<!-- agentloop:ui-link -->
[Open in AgentLoop UI](https://agentloop.thomas-guettler.de/issues/check-conditions/5)
<!-- /agentloop:ui-link -->

<!-- agentloop:issue-link -->
Closes #5 — Extend the ok-list. Example: Degraded=False AllObjectsAvailable
<!-- /agentloop:issue-link -->

Closes #5

## What changed

Extend the ok-list so the Tigera/Calico operator resources reported in the issue are treated as healthy:

- **`Degraded=False` (generic):** added `Degraded` to the negative-meaning condition suffixes in `conditionTypeHasNegativeMeaning`. `Degraded` is a standard negative-polarity condition across operators (Tigera, cert-manager, cluster/machine operators), so `Degraded=True` is bad and `Degraded=False` is healthy universally.
- **`Progressing=False AllObjectsAvailable` (scoped):** added two entries to `conditionLinesToIgnoreRegexs`, scoped by resource so `deployments Progressing=False ProgressDeadlineExceeded` (a genuine failure) keeps being reported:
  ```go
  regexp.MustCompile(`tigerastatuses Progressing=False AllObjectsAvailable`),
  regexp.MustCompile(`installations Progressing=False AllObjectsAvailable`),
  ```

The other lines in the issue's pasted output (`apiservices Available=False`, HPA `ScalingActive=False`, `deployments Available=False MinimumReplicasUnavailable` / `Progressing=False ProgressDeadlineExceeded`, `pods ContainersReady=False`) describe real problems and are intentionally left reported.

Also documented the generic `*Degraded=False will be ignored` behavior in the README.

## Verification

- Added `TestHandleConditionSkipsHealthyTigeraConditions` covering `tigerastatuses`/`installations` with `Degraded=False` and `Progressing=False AllObjectsAvailable` (0 rows), a generic `Degraded=False` (0 rows), and a guard that `deployments Progressing=False ProgressDeadlineExceeded` still produces a row.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- `golangci-lint run` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)